### PR TITLE
Enhance maturity usage and testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,42 @@ This Flask application calculates and visualizes option prices using several pri
 - Interactive volatility visualization
 - Calculation of Greeks (Delta, Gamma, Vega, Theta, Rho)
 
+## Architecture
+
+The application is driven by a small Flask server (`app.py`). Pricing logic is
+implemented in individual modules within `models/` and accessed via helper
+functions in `services.py`. HTML templates and static assets live under
+`templates/` and `static/`.
+
 ## Setup
+
+Create a virtual environment with Python 3.11 or newer and install the
+dependencies:
+
 ```bash
+python -m venv venv
+source venv/bin/activate
 pip install -r requirements.txt
+```
+
+Run the application:
+
+```bash
 python app.py
 ```
-Visit `http://127.0.0.1:5000`.
+
+Visit `http://127.0.0.1:5000` in your browser.
+
+## Running Tests
+
+Execute the unit tests with `pytest`:
+
+```bash
+pytest
+```
+
+Tests cover all pricing models and a simple check of the Flask `/calculate`
+route.
 
 ## Docker
 Run the app in a container:

--- a/app.py
+++ b/app.py
@@ -21,6 +21,7 @@ def visualize():
         symbol = request.form['symbol']
         strike_price = float(request.form['strike_price'])
         option_type = request.form['option_type']
+        maturity = float(request.form['maturity'])
         volatility = float(request.form['volatility']) / 100
         risk_free_rate = float(request.form['risk_free_rate']) / 100
         model_type = request.form['model_type']
@@ -32,8 +33,17 @@ def visualize():
 
         x_vals = np.linspace(0.01, 1.0, 50)
         option_prices = [
-            calculate_price(model_type, stock_price, strike_price, 1, risk_free_rate, sigma,
-                             option_type, steps, simulations)
+            calculate_price(
+                model_type,
+                stock_price,
+                strike_price,
+                maturity,
+                risk_free_rate,
+                sigma,
+                option_type,
+                steps,
+                simulations,
+            )
             for sigma in x_vals
         ]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,62 @@
 import math
+import numpy as np
+import pytest
+from flask import Flask
+
 from models.black_scholes import black_scholes
+from models.binomial_tree import binomial_tree
+from models.monte_carlo import monte_carlo
+from models.bjerksund_stensland import bjerksund_stensland
+from app import app
+from unittest.mock import patch
+
+
+@pytest.fixture
+def client():
+    with app.test_client() as client:
+        yield client
 
 def test_black_scholes_call():
     price = black_scholes(100, 100, 1, 0.05, 0.2, 'call')
     assert math.isclose(price, 10.4506, rel_tol=1e-4)
+
+
+def test_binomial_tree_put():
+    price = binomial_tree(100, 100, 1, 0.05, 0.2, 100, 'put')
+    assert math.isclose(price, 5.5536, rel_tol=1e-2)
+
+
+def test_monte_carlo_put_seeded():
+    np.random.seed(0)
+    price = monte_carlo(100, 100, 1, 0.05, 0.2, 50000, 'put')
+    assert math.isclose(price, 5.53, rel_tol=5e-2)
+
+
+def test_bjerksund_equals_black_scholes_call():
+    price = bjerksund_stensland(100, 100, 1, 0.05, 0.2, 'call')
+    bs_price = black_scholes(100, 100, 1, 0.05, 0.2, 'call')
+    assert math.isclose(price, bs_price, rel_tol=1e-8)
+
+
+def test_calculate_route(client):
+    class DummyTicker:
+        def history(self, period='1d'):
+            import pandas as pd
+            return pd.DataFrame({'Close': [150.0]})
+
+    with patch('yfinance.Ticker', return_value=DummyTicker()):
+        response = client.post('/calculate', data={
+            'symbol': 'AAPL',
+            'strike_price': '100',
+            'maturity': '1',
+            'option_type': 'call',
+            'volatility': '20',
+            'risk_free_rate': '5',
+            'model_type': 'black_scholes',
+            'steps': '100',
+            'simulations': '1000',
+        })
+    assert response.status_code == 200
+
+
+


### PR DESCRIPTION
## Summary
- hook visualization route up to user-provided maturity
- expand test suite for all pricing models and Flask route
- document setup and testing procedures in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d3eb2710832a95f1a26a7b392744